### PR TITLE
Fixed position of note block entity not getting updated correctly when attached to turtle

### DIFF
--- a/src/main/java/com/austinv11/peripheralsplusplus/tiles/TileEntityNoteBlock.java
+++ b/src/main/java/com/austinv11/peripheralsplusplus/tiles/TileEntityNoteBlock.java
@@ -142,9 +142,11 @@ public class TileEntityNoteBlock extends MountedTileEntity {
 
     public void updateEntity(boolean turtle) {
         if(turtle) {
-            this.xCoord = this.turtle.getPosition().posX;
-            this.yCoord = this.turtle.getPosition().posY;
-            this.zCoord = this.turtle.getPosition().posZ;
+            location = new Location(this.turtle.getPosition().posX, this.turtle.getPosition().posY,
+                    this.turtle.getPosition().posZ, this.turtle.getWorld());
+            this.xCoord = (int) location.getX();
+            this.yCoord = (int) location.getY();
+            this.zCoord = (int) location.getZ();
         }
         updateEntity();
     }


### PR DESCRIPTION
- Local field "location" was not updated resulting in the note particles and sound to be executed at wrong location if the turtle moved.