### PR TITLE
Added Sign Reading Turtle

### DIFF
--- a/src/main/java/com/austinv11/peripheralsplusplus/PeripheralsPlusPlus.java
+++ b/src/main/java/com/austinv11/peripheralsplusplus/PeripheralsPlusPlus.java
@@ -139,6 +139,7 @@ public class PeripheralsPlusPlus {
 		registerUpgrade(new TurtleEnvironmentScanner());
 		registerUpgrade(new TurtleFeeder());
 		registerUpgrade(new TurtleShear());
+		registerUpgrade(new TurtleSignReader());
 		if (Loader.isModLoaded("ProjRed|Exploration")) {
 			Logger.info("Project Red Exploration is loaded! Registering Project Red tools turtle upgrades...");
 			registerProjRedUpgrades();

--- a/src/main/java/com/austinv11/peripheralsplusplus/reference/Config.java
+++ b/src/main/java/com/austinv11/peripheralsplusplus/reference/Config.java
@@ -41,6 +41,7 @@ public class Config {
 	public static boolean enableSmartHelmet = true;
     public static double noteBlockRange = 16;
     public static boolean noteBlockEnabled = true;
+	public static boolean enableReaderTurtle = true;
 
 	public static void setWhitelist(int[] dims) {
 		for (int i : dims)

--- a/src/main/java/com/austinv11/peripheralsplusplus/reference/Reference.java
+++ b/src/main/java/com/austinv11/peripheralsplusplus/reference/Reference.java
@@ -20,6 +20,7 @@ public class Reference {
 	public static final int SPEAKER_UPGRADE = 125;
 	public static final int TANK_UPGRADE = 126; //TODO Remember to update the id list on the wiki
     public static final int NOTE_BLOCK_UPGRADE = 127;
+	public static final int SIGN_READER_UPGRADE = 128;
 
 	public static enum GUIs {
 		ANALYZER,ROCKET;

--- a/src/main/java/com/austinv11/peripheralsplusplus/turtles/TurtleSignReader.java
+++ b/src/main/java/com/austinv11/peripheralsplusplus/turtles/TurtleSignReader.java
@@ -1,0 +1,50 @@
+package com.austinv11.peripheralsplusplus.turtles;
+
+import com.austinv11.peripheralsplusplus.init.ModBlocks;
+import com.austinv11.peripheralsplusplus.init.ModItems;
+import com.austinv11.peripheralsplusplus.reference.Reference;
+import com.austinv11.peripheralsplusplus.turtles.peripherals.PeripheralSignReader;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import dan200.computercraft.api.peripheral.IPeripheral;
+import dan200.computercraft.api.turtle.*;
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.IIcon;
+
+public class TurtleSignReader implements ITurtleUpgrade
+{
+    @Override
+    public int getUpgradeID() { return Reference.SIGN_READER_UPGRADE; }
+
+    @Override
+    public String getUnlocalisedAdjective() { return "peripheralsplusplus.turtleUpgrade.signReader"; }
+
+    @Override
+    public TurtleUpgradeType getType() { return TurtleUpgradeType.Peripheral; }
+
+    @Override
+    public ItemStack getCraftingItem() { return new ItemStack(Items.sign); }
+
+    @Override
+    public IPeripheral createPeripheral(ITurtleAccess turtle, TurtleSide side)
+    {
+        return new PeripheralSignReader(turtle);
+    }
+
+    @Override
+    public TurtleCommandResult useTool(ITurtleAccess turtle, TurtleSide side, TurtleVerb verb, int direction)
+    {
+        return null;
+    }
+
+    @SideOnly(Side.CLIENT)
+    @Override
+    public IIcon getIcon(ITurtleAccess turtle, TurtleSide side)
+    {
+        return ModBlocks.dummyBlock.getIcon(0,0);
+    }
+
+    @Override
+    public void update(ITurtleAccess turtle, TurtleSide side) {}
+}

--- a/src/main/java/com/austinv11/peripheralsplusplus/turtles/peripherals/PeripheralSignReader.java
+++ b/src/main/java/com/austinv11/peripheralsplusplus/turtles/peripherals/PeripheralSignReader.java
@@ -1,0 +1,61 @@
+package com.austinv11.peripheralsplusplus.turtles.peripherals;
+
+import com.austinv11.peripheralsplusplus.reference.Config;
+import com.austinv11.peripheralsplusplus.utils.Logger;
+import dan200.computercraft.api.lua.ILuaContext;
+import dan200.computercraft.api.lua.LuaException;
+import dan200.computercraft.api.peripheral.IComputerAccess;
+import dan200.computercraft.api.peripheral.IPeripheral;
+import dan200.computercraft.api.turtle.ITurtleAccess;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockSign;
+import net.minecraft.tileentity.TileEntitySign;
+import net.minecraft.util.Facing;
+import sun.rmi.log.LogHandler;
+
+public class PeripheralSignReader extends MountedPeripheral
+{
+    private ITurtleAccess turtle;
+
+    public PeripheralSignReader(ITurtleAccess turtle) {
+        this.turtle = turtle;
+    }
+
+    @Override
+    public String getType()
+    {
+        return "signReader";
+    }
+
+    @Override
+    public String[] getMethodNames() { return new String[] {"read"}; }
+
+    @Override
+    public Object[] callMethod(IComputerAccess computer, ILuaContext context, int method, Object[] arguments) throws LuaException, InterruptedException
+    {
+        if (!Config.enableReaderTurtle)
+            throw new LuaException("Sign Reading Turtles have been disabled");
+        if (method == 0)
+        {
+            int blockX = turtle.getPosition().posX+ Facing.offsetsXForSide[turtle.getDirection()];
+            int blockY = turtle.getPosition().posY+Facing.offsetsYForSide[turtle.getDirection()];
+            int blockZ = turtle.getPosition().posZ+Facing.offsetsZForSide[turtle.getDirection()];
+
+            Block blockFacing = turtle.getWorld().getBlock(blockX, blockY, blockZ);
+
+            if (blockFacing instanceof BlockSign)
+            {
+                Logger.info("Sign Stuff");
+                TileEntitySign tileEntitySign = (TileEntitySign) turtle.getWorld().getTileEntity(blockX, blockY, blockZ);
+                return new Object[] {tileEntitySign.signText[0], tileEntitySign.signText[1], tileEntitySign.signText[2], tileEntitySign.signText[3]};
+            }
+        }
+        return new Object[0];
+    }
+
+    @Override
+    public boolean equals(IPeripheral other)
+    {
+        return (other == this);
+    }
+}

--- a/src/main/java/com/austinv11/peripheralsplusplus/utils/ConfigurationHandler.java
+++ b/src/main/java/com/austinv11/peripheralsplusplus/utils/ConfigurationHandler.java
@@ -66,6 +66,7 @@ public class ConfigurationHandler {
 			Config.enableSmartHelmet = config.get("Smart Helmet", "enableSmartHelmet", true, "If disabled, the recipes will be disabled and the current peripherals would cease to work").getBoolean(true);
             Config.noteBlockRange = config.get("NoteBlock", "noteBlockRange", 16.0, "Audible range for the noteblock").getDouble(16.0);
             Config.noteBlockEnabled = config.get("NoteBlock", "noteBlockEnabled", true, "If disabled, crafting recipes will be removed and existing items will stop functioning").getBoolean(true);
+			Config.enableReaderTurtle = config.get("Sign Reading Turtle", "enableReaderTurtle", true, "If disabled, the recipe will be disabled and the current peripherals would cease to work").getBoolean();
 		}catch (Exception e){//Log exception
 			Logger.warn("Config exception!");
 			Logger.warn(e.getStackTrace());

--- a/src/main/resources/assets/peripheralsplusplus/lang/en_US.lang
+++ b/src/main/resources/assets/peripheralsplusplus/lang/en_US.lang
@@ -41,6 +41,7 @@ peripheralsplusplus.turtleUpgrade.feeder=Feeding
 peripheralsplusplus.turtleUpgrade.speaker=Talkative
 peripheralsplusplus.turtleUpgrade.tank=Thirsty
 peripheralsplusplus.turtleUpgrade.note=Musical
+peripheralsplusplus.turtleUpgrade.signReader=Reading
 
 #GUIs
 peripheralsplusplus.inv.analyzer=Analyzer


### PR DESCRIPTION
Added a turtle upgrade with the ability to read the text on signs. 
Only method: peripheral.read() returns a table containing each line of the sign.
Currently has a temporary recipe and texture. 

Application:
![](http://puu.sh/g0siH/a5e7a7f353.jpg)
![](http://puu.sh/g0skJ/133dbf919f.png)
![](http://puu.sh/g0slG/822920de60.png)



