### PR TITLE
Changed Peripherals++ to only use a single Peripheral Provider and made Provider a lot more safe.

### DIFF
--- a/src/main/java/com/austinv11/peripheralsplusplus/PeripheralsPlusPlus.java
+++ b/src/main/java/com/austinv11/peripheralsplusplus/PeripheralsPlusPlus.java
@@ -27,6 +27,7 @@ import com.austinv11.peripheralsplusplus.reference.Config;
 import com.austinv11.peripheralsplusplus.reference.Reference;
 import com.austinv11.peripheralsplusplus.turtles.*;
 import com.austinv11.peripheralsplusplus.turtles.peripherals.PeripheralChunkLoader;
+import com.austinv11.peripheralsplusplus.utils.IPlusPlusPeripheral;
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.SidedProxy;
@@ -112,29 +113,7 @@ public class PeripheralsPlusPlus {
 		NetworkRegistry.INSTANCE.registerGuiHandler(instance, new GuiHandler());
 		LOGGER.info("Registering peripherals...");
 		proxy.registerTileEntities();
-		ComputerCraftAPI.registerPeripheralProvider(new BlockChatBox());
-		ComputerCraftAPI.registerPeripheralProvider(new BlockPlayerSensor());
-		ComputerCraftAPI.registerPeripheralProvider(new BlockOreDictionary());
-		if (Loader.isModLoaded(ModIds.Forestry)) {
-			LOGGER.info("Forestry is loaded! Registering analyzer peripherals...");
-			ComputerCraftAPI.registerPeripheralProvider(new BlockAnalyzerBee());
-			ComputerCraftAPI.registerPeripheralProvider(new BlockAnalyzerTree());
-			ComputerCraftAPI.registerPeripheralProvider(new BlockAnalyzerButterfly());
-		} else
-			LOGGER.info("Forestry not found, skipping analyzer peripherals");
-		ComputerCraftAPI.registerPeripheralProvider(new BlockTeleporter());
-		ComputerCraftAPI.registerPeripheralProvider(new BlockTeleporterT2());
-		ComputerCraftAPI.registerPeripheralProvider(new BlockEnvironmentScanner());
-		ComputerCraftAPI.registerPeripheralProvider(new BlockSpeaker());
-		ComputerCraftAPI.registerPeripheralProvider(new BlockAntenna());
-		ComputerCraftAPI.registerPeripheralProvider(new BlockPeripheralContainer());
-		if (Loader.isModLoaded(ModIds.AppliedEnergistics2)) {
-			LOGGER.info("Applied Energistics is loaded! Registering the ME Bridge...");
-			ComputerCraftAPI.registerPeripheralProvider(new BlockMEBridge());
-		}else
-			LOGGER.info("Applied Energistics not found, skipping the ME Bridge");
-		ComputerCraftAPI.registerPeripheralProvider(new BlockTimeSensor());
-		ComputerCraftAPI.registerPeripheralProvider(new BlockInteractiveSorter());
+		ComputerCraftAPI.registerPeripheralProvider(new IPlusPlusPeripheral.Provider());
 		LOGGER.info("Registering turtle upgrades...");
 		registerUpgrade(new TurtleChatBox());
 		registerUpgrade(new TurtlePlayerSensor());

--- a/src/main/java/com/austinv11/peripheralsplusplus/blocks/BlockAnalyzer.java
+++ b/src/main/java/com/austinv11/peripheralsplusplus/blocks/BlockAnalyzer.java
@@ -20,7 +20,7 @@ import net.minecraft.world.World;
 
 import java.util.ArrayList;
 
-public abstract class BlockAnalyzer extends BlockContainer implements IPeripheralProvider {
+public abstract class BlockAnalyzer extends BlockContainer {
 
 	public BlockAnalyzer() {
 		super(Material.rock);
@@ -74,8 +74,4 @@ public abstract class BlockAnalyzer extends BlockContainer implements IPeriphera
 		return true;
 	}
 
-	@Override
-	public IPeripheral getPeripheral(World world, int x, int y, int z, int side ) {
-		return (IPeripheral) world.getTileEntity(x,y,z);
-	}
 }

--- a/src/main/java/com/austinv11/peripheralsplusplus/blocks/BlockAntenna.java
+++ b/src/main/java/com/austinv11/peripheralsplusplus/blocks/BlockAntenna.java
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-public class BlockAntenna extends BlockPPP implements ITileEntityProvider, IPeripheralProvider {
+public class BlockAntenna extends BlockPPP implements ITileEntityProvider {
 
 	public BlockAntenna() {
 		super();
@@ -55,11 +55,6 @@ public class BlockAntenna extends BlockPPP implements ITileEntityProvider, IPeri
 	public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase entity, ItemStack itemStack) {
 		int direction = BlockPistonBase.determineOrientation(world, x, y, z, entity);
 		world.setBlockMetadataWithNotify(x, y, z, direction, 2);
-	}
-
-	@Override
-	public IPeripheral getPeripheral(World world, int x, int y, int z, int side) {
-		return (IPeripheral) world.getTileEntity(x,y,z);
 	}
 
 	@Override

--- a/src/main/java/com/austinv11/peripheralsplusplus/blocks/BlockChatBox.java
+++ b/src/main/java/com/austinv11/peripheralsplusplus/blocks/BlockChatBox.java
@@ -7,7 +7,7 @@ import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
-public class BlockChatBox extends BlockPPP implements ITileEntityProvider, IPeripheralProvider {
+public class BlockChatBox extends BlockPPP implements ITileEntityProvider {
 
 	public BlockChatBox() {
 		super();
@@ -25,8 +25,4 @@ public class BlockChatBox extends BlockPPP implements ITileEntityProvider, IPeri
 		return true;
 	}
 
-	@Override
-	public IPeripheral getPeripheral(World world, int x, int y, int z, int side ) {
-		return (IPeripheral) world.getTileEntity(x,y,z);
-	}
 }

--- a/src/main/java/com/austinv11/peripheralsplusplus/blocks/BlockEnvironmentScanner.java
+++ b/src/main/java/com/austinv11/peripheralsplusplus/blocks/BlockEnvironmentScanner.java
@@ -7,7 +7,7 @@ import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
-public class BlockEnvironmentScanner extends BlockPPP implements ITileEntityProvider, IPeripheralProvider {
+public class BlockEnvironmentScanner extends BlockPPP implements ITileEntityProvider {
 
 	public BlockEnvironmentScanner() {
 		super();
@@ -24,8 +24,4 @@ public class BlockEnvironmentScanner extends BlockPPP implements ITileEntityProv
 		return true;
 	}
 
-	@Override
-	public IPeripheral getPeripheral(World world, int x, int y, int z, int side) {
-		return (IPeripheral) world.getTileEntity(x,y,z);
-	}
 }

--- a/src/main/java/com/austinv11/peripheralsplusplus/blocks/BlockInteractiveSorter.java
+++ b/src/main/java/com/austinv11/peripheralsplusplus/blocks/BlockInteractiveSorter.java
@@ -19,7 +19,7 @@ import net.minecraft.world.World;
 
 import java.util.ArrayList;
 
-public class BlockInteractiveSorter extends BlockContainer implements IPeripheralProvider {
+public class BlockInteractiveSorter extends BlockContainer {
 	
 	public BlockInteractiveSorter() {
 		super(Material.rock);
@@ -27,12 +27,7 @@ public class BlockInteractiveSorter extends BlockContainer implements IPeriphera
 		this.setCreativeTab(CreativeTabPPP.PPP_TAB);
 		this.setHardness(4f);
 	}
-	
-	@Override
-	public IPeripheral getPeripheral(World world, int x, int y, int z, int side) {
-		return (IPeripheral) world.getTileEntity(x,y,z);
-	}
-	
+
 	@Override
 	public TileEntity createNewTileEntity(World world, int meta) {
 		return new TileEntityInteractiveSorter();

--- a/src/main/java/com/austinv11/peripheralsplusplus/blocks/BlockMEBridge.java
+++ b/src/main/java/com/austinv11/peripheralsplusplus/blocks/BlockMEBridge.java
@@ -1,8 +1,6 @@
 package com.austinv11.peripheralsplusplus.blocks;
 
 import com.austinv11.peripheralsplusplus.tiles.TileEntityMEBridge;
-import dan200.computercraft.api.peripheral.IPeripheral;
-import dan200.computercraft.api.peripheral.IPeripheralProvider;
 import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
@@ -10,16 +8,11 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
-public class BlockMEBridge extends BlockPPP implements ITileEntityProvider, IPeripheralProvider {
+public class BlockMEBridge extends BlockPPP implements ITileEntityProvider {
 
 	public BlockMEBridge() {
 		super();
 		this.setBlockName("meBridge");
-	}
-
-	@Override
-	public IPeripheral getPeripheral(World world, int x, int y, int z, int side) {
-		return (IPeripheral)world.getTileEntity(x,y,z);
 	}
 
 	@Override

--- a/src/main/java/com/austinv11/peripheralsplusplus/blocks/BlockNote.java
+++ b/src/main/java/com/austinv11/peripheralsplusplus/blocks/BlockNote.java
@@ -1,22 +1,15 @@
 package com.austinv11.peripheralsplusplus.blocks;
 
 import com.austinv11.peripheralsplusplus.tiles.TileEntityNoteBlock;
-import dan200.computercraft.api.peripheral.IPeripheral;
-import dan200.computercraft.api.peripheral.IPeripheralProvider;
 import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
-public class BlockNote extends BlockPPP implements ITileEntityProvider, IPeripheralProvider {
+public class BlockNote extends BlockPPP implements ITileEntityProvider {
 
 	public BlockNote() {
 		super();
 		this.setBlockName("noteBlock");
-	}
-
-	@Override
-	public IPeripheral getPeripheral(World world, int x, int y, int z, int side) {
-		return (IPeripheral) world.getTileEntity(x, y, z);
 	}
 
 	@Override

--- a/src/main/java/com/austinv11/peripheralsplusplus/blocks/BlockOreDictionary.java
+++ b/src/main/java/com/austinv11/peripheralsplusplus/blocks/BlockOreDictionary.java
@@ -2,14 +2,12 @@ package com.austinv11.peripheralsplusplus.blocks;
 
 import com.austinv11.peripheralsplusplus.reference.Config;
 import com.austinv11.peripheralsplusplus.tiles.TileEntityOreDictionary;
-import dan200.computercraft.api.peripheral.IPeripheral;
-import dan200.computercraft.api.peripheral.IPeripheralProvider;
 import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
-public class BlockOreDictionary extends BlockPPP implements ITileEntityProvider, IPeripheralProvider {
+public class BlockOreDictionary extends BlockPPP implements ITileEntityProvider {
 
 	public BlockOreDictionary() {
 		super();
@@ -24,11 +22,6 @@ public class BlockOreDictionary extends BlockPPP implements ITileEntityProvider,
 	@Override
 	public boolean hasTileEntity(int metadata) {
 		return true;
-	}
-
-	@Override
-	public IPeripheral getPeripheral(World world, int x, int y, int z, int side) {
-		return (IPeripheral) world.getTileEntity(x,y,z);
 	}
 
 	@Override

--- a/src/main/java/com/austinv11/peripheralsplusplus/blocks/BlockPeripheralContainer.java
+++ b/src/main/java/com/austinv11/peripheralsplusplus/blocks/BlockPeripheralContainer.java
@@ -18,18 +18,13 @@ import net.minecraft.world.World;
 import java.util.ArrayList;
 import java.util.List;
 
-public class BlockPeripheralContainer extends BlockPPP implements ITileEntityProvider, IPeripheralProvider{
+public class BlockPeripheralContainer extends BlockPPP implements ITileEntityProvider {
 
 //	BlockSnapshot blockSnapshot;
 
 	public BlockPeripheralContainer() {
 		super();
 		this.setBlockName("peripheralContainer");
-	}
-
-	@Override
-	public IPeripheral getPeripheral(World world, int x, int y, int z, int side) {
-		return (IPeripheral)world.getTileEntity(x,y,z);
 	}
 
 	@Override

--- a/src/main/java/com/austinv11/peripheralsplusplus/blocks/BlockPlayerInterface.java
+++ b/src/main/java/com/austinv11/peripheralsplusplus/blocks/BlockPlayerInterface.java
@@ -19,8 +19,7 @@ import net.minecraft.world.World;
 
 import java.util.ArrayList;
 
-public class BlockPlayerInterface extends BlockContainer implements IPeripheralProvider
-{
+public class BlockPlayerInterface extends BlockContainer {
 
     public BlockPlayerInterface()
     {
@@ -34,12 +33,6 @@ public class BlockPlayerInterface extends BlockContainer implements IPeripheralP
     public TileEntity createNewTileEntity(World world, int p_149915_2_)
     {
         return new TileEntityPlayerInterface();
-    }
-
-    @Override
-    public IPeripheral getPeripheral(World world, int x, int y, int z, int side)
-    {
-        return (IPeripheral) world.getTileEntity(x, y, z);
     }
 
     @Override

--- a/src/main/java/com/austinv11/peripheralsplusplus/blocks/BlockPlayerSensor.java
+++ b/src/main/java/com/austinv11/peripheralsplusplus/blocks/BlockPlayerSensor.java
@@ -2,14 +2,12 @@ package com.austinv11.peripheralsplusplus.blocks;
 
 import com.austinv11.peripheralsplusplus.reference.Config;
 import com.austinv11.peripheralsplusplus.tiles.TileEntityPlayerSensor;
-import dan200.computercraft.api.peripheral.IPeripheral;
-import dan200.computercraft.api.peripheral.IPeripheralProvider;
 import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
-public class BlockPlayerSensor extends BlockPPP implements ITileEntityProvider, IPeripheralProvider {
+public class BlockPlayerSensor extends BlockPPP implements ITileEntityProvider {
 
 	public BlockPlayerSensor() {
 		super();
@@ -24,11 +22,6 @@ public class BlockPlayerSensor extends BlockPPP implements ITileEntityProvider, 
 	@Override
 	public boolean hasTileEntity(int metadata) {
 		return true;
-	}
-
-	@Override
-	public IPeripheral getPeripheral(World world, int x, int y, int z, int side ) {
-		return (IPeripheral) world.getTileEntity(x,y,z);
 	}
 
 	@Override

--- a/src/main/java/com/austinv11/peripheralsplusplus/blocks/BlockSpeaker.java
+++ b/src/main/java/com/austinv11/peripheralsplusplus/blocks/BlockSpeaker.java
@@ -5,8 +5,6 @@ import com.austinv11.peripheralsplusplus.reference.Reference;
 import com.austinv11.peripheralsplusplus.tiles.TileEntitySpeaker;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import dan200.computercraft.api.peripheral.IPeripheral;
-import dan200.computercraft.api.peripheral.IPeripheralProvider;
 import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.tileentity.TileEntity;
@@ -15,7 +13,7 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-public class BlockSpeaker extends BlockPPP implements ITileEntityProvider, IPeripheralProvider {
+public class BlockSpeaker extends BlockPPP implements ITileEntityProvider {
 
 	public IIcon frontIcon;
 
@@ -32,11 +30,6 @@ public class BlockSpeaker extends BlockPPP implements ITileEntityProvider, IPeri
 	@Override
 	public boolean hasTileEntity(int metadata) {
 		return true;
-	}
-
-	@Override
-	public IPeripheral getPeripheral(World world, int x, int y, int z, int side ) {
-		return (IPeripheral) world.getTileEntity(x,y,z);
 	}
 
 	@Override

--- a/src/main/java/com/austinv11/peripheralsplusplus/blocks/BlockTeleporter.java
+++ b/src/main/java/com/austinv11/peripheralsplusplus/blocks/BlockTeleporter.java
@@ -18,7 +18,7 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
-public class BlockTeleporter extends BlockPPP implements ITileEntityProvider, IPeripheralProvider {
+public class BlockTeleporter extends BlockPPP implements ITileEntityProvider {
 
 	public IIcon frontIcon;
 
@@ -35,11 +35,6 @@ public class BlockTeleporter extends BlockPPP implements ITileEntityProvider, IP
 	@Override
 	public boolean hasTileEntity(int metadata) {
 		return true;
-	}
-
-	@Override
-	public IPeripheral getPeripheral(World world, int x, int y, int z, int side ) {
-		return (IPeripheral) world.getTileEntity(x,y,z);
 	}
 
 	@Override

--- a/src/main/java/com/austinv11/peripheralsplusplus/blocks/BlockTimeSensor.java
+++ b/src/main/java/com/austinv11/peripheralsplusplus/blocks/BlockTimeSensor.java
@@ -7,16 +7,11 @@ import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
-public class BlockTimeSensor extends BlockPPP implements ITileEntityProvider, IPeripheralProvider {
+public class BlockTimeSensor extends BlockPPP implements ITileEntityProvider {
 
 	public BlockTimeSensor() {
 		super();
 		this.setBlockName("timeSensor");
-	}
-
-	@Override
-	public IPeripheral getPeripheral(World world, int x, int y, int z, int side) {
-		return (IPeripheral) world.getTileEntity(x, y, z);
 	}
 
 	@Override

--- a/src/main/java/com/austinv11/peripheralsplusplus/init/ModBlocks.java
+++ b/src/main/java/com/austinv11/peripheralsplusplus/init/ModBlocks.java
@@ -1,5 +1,6 @@
 package com.austinv11.peripheralsplusplus.init;
 
+import com.austinv11.peripheralsplusplus.PeripheralsPlusPlus;
 import com.austinv11.peripheralsplusplus.blocks.*;
 import com.austinv11.peripheralsplusplus.items.ItemBlockPeripheralContainer;
 import com.austinv11.peripheralsplusplus.items.ItemBlockTurtle;
@@ -41,21 +42,26 @@ public class ModBlocks {
 		}
 		GameRegistry.registerBlock(oreDictionary, "oreDictionary");
 		if (Loader.isModLoaded("Forestry")) {
+			PeripheralsPlusPlus.LOGGER.info("Forestry is loaded! Registering analyzer peripherals...");
 			beeAnalyzer = new BlockAnalyzerBee();
 			GameRegistry.registerBlock(beeAnalyzer, "beeAnalyzer");
 			treeAnalyzer = new BlockAnalyzerTree();
 			GameRegistry.registerBlock(treeAnalyzer, "treeAnalyzer");
 			butterflyAnalyzer = new BlockAnalyzerButterfly();
 			GameRegistry.registerBlock(butterflyAnalyzer, "butterflyAnalyzer");
-		}
+		} else
+			PeripheralsPlusPlus.LOGGER.info("Forestry not found, skipping analyzer peripherals");
 		GameRegistry.registerBlock(teleporter, "teleporter");
 		GameRegistry.registerBlock(teleporterT2, "teleporterT2");
 		GameRegistry.registerBlock(environmentScanner, "environmentScanner");
 		GameRegistry.registerBlock(speaker, "speaker");
 		GameRegistry.registerBlock(antenna, "antenna");
 		GameRegistry.registerBlock(peripheralContainer, ItemBlockPeripheralContainer.class, "peripheralContainer");
-		if (Loader.isModLoaded("appliedenergistics2"))
+		if (Loader.isModLoaded("appliedenergistics2")) {
+			PeripheralsPlusPlus.LOGGER.info("Applied Energistics is loaded! Registering the ME Bridge...");
 			GameRegistry.registerBlock(meBridge, "meBridge");
+		} else
+			PeripheralsPlusPlus.LOGGER.info("Applied Energistics not found, skipping the ME Bridge");
 		GameRegistry.registerBlock(dummyBlock, "dummyBlock");
 		GameRegistry.registerBlock(noteBlock, "noteBlock");
 		GameRegistry.registerBlock(turtle, ItemBlockTurtle.class, "turtle");

--- a/src/main/java/com/austinv11/peripheralsplusplus/tiles/MountedNetworkedTileEntity.java
+++ b/src/main/java/com/austinv11/peripheralsplusplus/tiles/MountedNetworkedTileEntity.java
@@ -2,10 +2,10 @@ package com.austinv11.peripheralsplusplus.tiles;
 
 import com.austinv11.collectiveframework.minecraft.tiles.NetworkedTileEntity;
 import com.austinv11.peripheralsplusplus.mount.DynamicMount;
+import com.austinv11.peripheralsplusplus.utils.IPlusPlusPeripheral;
 import dan200.computercraft.api.peripheral.IComputerAccess;
-import dan200.computercraft.api.peripheral.IPeripheral;
 
-public abstract class MountedNetworkedTileEntity extends NetworkedTileEntity implements IPeripheral {
+public abstract class MountedNetworkedTileEntity extends NetworkedTileEntity implements IPlusPlusPeripheral {
 
 	public MountedNetworkedTileEntity() {
 		super();

--- a/src/main/java/com/austinv11/peripheralsplusplus/tiles/MountedTileEntity.java
+++ b/src/main/java/com/austinv11/peripheralsplusplus/tiles/MountedTileEntity.java
@@ -1,11 +1,11 @@
 package com.austinv11.peripheralsplusplus.tiles;
 
 import com.austinv11.peripheralsplusplus.mount.DynamicMount;
+import com.austinv11.peripheralsplusplus.utils.IPlusPlusPeripheral;
 import dan200.computercraft.api.peripheral.IComputerAccess;
-import dan200.computercraft.api.peripheral.IPeripheral;
 import net.minecraft.tileentity.TileEntity;
 
-public abstract class MountedTileEntity extends TileEntity implements IPeripheral {
+public abstract class MountedTileEntity extends TileEntity implements IPlusPlusPeripheral {
 
 	public MountedTileEntity() {
 		super();

--- a/src/main/java/com/austinv11/peripheralsplusplus/tiles/MountedTileEntityInventory.java
+++ b/src/main/java/com/austinv11/peripheralsplusplus/tiles/MountedTileEntityInventory.java
@@ -2,10 +2,10 @@ package com.austinv11.peripheralsplusplus.tiles;
 
 import com.austinv11.collectiveframework.minecraft.tiles.TileEntityInventory;
 import com.austinv11.peripheralsplusplus.mount.DynamicMount;
+import com.austinv11.peripheralsplusplus.utils.IPlusPlusPeripheral;
 import dan200.computercraft.api.peripheral.IComputerAccess;
-import dan200.computercraft.api.peripheral.IPeripheral;
 
-public abstract class MountedTileEntityInventory extends TileEntityInventory implements IPeripheral {
+public abstract class MountedTileEntityInventory extends TileEntityInventory implements IPlusPlusPeripheral {
 
 	public MountedTileEntityInventory() {
 		super();

--- a/src/main/java/com/austinv11/peripheralsplusplus/utils/IPlusPlusPeripheral.java
+++ b/src/main/java/com/austinv11/peripheralsplusplus/utils/IPlusPlusPeripheral.java
@@ -1,0 +1,24 @@
+package com.austinv11.peripheralsplusplus.utils;
+
+import dan200.computercraft.api.peripheral.IPeripheral;
+import dan200.computercraft.api.peripheral.IPeripheralProvider;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+
+/**
+ * Implement this on any TileEntity in Peripherals++ instead of {@code IPeripheral} to have a way of detecting if a peripheral is from this mod.
+ */
+public interface IPlusPlusPeripheral extends IPeripheral {
+
+	/**
+	 * This is the common provider for all Peripherals++ TileEntities
+	 */
+	public static class Provider implements IPeripheralProvider {
+
+		@Override
+		public IPeripheral getPeripheral(World world, int x, int y, int z, int side) {
+			TileEntity tile = world.getTileEntity(x, y, z);
+			return tile instanceof IPlusPlusPeripheral ? (IPlusPlusPeripheral) tile : null;
+		}
+	}
+}


### PR DESCRIPTION
This change makes Peripherals++ only add a single Peripheral Provider that will return the correct peripheral for any TileEntity implementing `IPlusPlusPeripheral`. Not only is it a lot more clean, but it is also a lot more safe as you previously were casting the TileEntity to `IPeripheral` without checking if it is one of your TileEntities at all.

If you want to add a new TileEntity, simply ensure that it or one of its superclasses implements `IPlusPlusPeripheral`. There is no need to add new Peripheral Providers anymore.

I moved the log messages for registering Forestry/AE2 blocks to ModBlocks so they still appear.

You might need to clean up imports after merging this; I tried to change as little as possible with this Pull Request.

This will close asiekierka/Computronics#147 as that issue was caused by your Providers throwing a `ClassCastException`.